### PR TITLE
input/stale: add

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ following fields:
 - __user:__ GitHub user (required)
 - __token:__ GitHub OpenAuth token (required)
 
+### stale(organization, auth, opts?)
+Check for stale repositories. By default projects are considered stale after 6
+months of no updates. Opts has the following fields:
+- __offset:__ offset in months before a project is considered stale. Defaults
+  to 6
+
 ## Output
 ### stdout(opts)
 Report to stdout. If `opts.summary=true` it will report a summary only.

--- a/input/stale.js
+++ b/input/stale.js
@@ -1,0 +1,54 @@
+const ghutils = require('ghutils')
+const assert = require('assert')
+
+const name = 'stale'
+
+module.exports = stale
+
+// check if there are stale repositories
+// offset defaults to 6 months
+// (str, obj) -> fn -> null
+function stale (org, auth, opts) {
+  opts = opts || {}
+
+  const ghOpts = ghutils.makeOptions(auth)
+  const offset = 2629746000 * (opts.offset || 6)
+  const threshold = Date.now() - offset
+
+  assert.equal(typeof org, 'string', 'org must be a string')
+  assert.equal(typeof auth, 'object', 'auth must be an object')
+  assert.equal(typeof auth.user, 'string', 'auth.user must be a string')
+  assert.equal(typeof auth.token, 'string', 'auth.token must be a string')
+
+  return function (cb) {
+    var uri = 'https://api.github.com/orgs/'
+    uri += org
+    uri += '/repos?type=sources'
+
+    ghutils.lister(auth, uri, ghOpts, function (err, res) {
+      if (err) return cb(err)
+      cb(null, format(res))
+    })
+  }
+
+  function format (data) {
+    const fails = data.reduce(function (arr, chunk) {
+      const lastUpdate = new Date(chunk.pushed_at).getTime()
+      if (lastUpdate < threshold) {
+        arr.push({ name: name, type: 'fail', data: chunk.html_url })
+      }
+      return arr
+    }, [])
+
+    const summary = {
+      name: name,
+      type: 'summary',
+      data: {
+        total: fails.length,
+        fail: fails.length
+      }
+    }
+
+    return fails.concat(summary)
+  }
+}


### PR DESCRIPTION
Adds the `stale` check which checks for stale projects on an organization. Thanks!

cc/ @rprieto @TabDigital/public-api 