### PR TITLE
output/csv: add

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ fields:
 - __output:__ path to write to. Writes to `process.stdout` by default
 - __fail:__ determine if errors should be reported. Defaults to `true`
 
+### csv(opts)
+Transforms output into a stream of `csv`. Can either write to stdout or a file.
+`opts` has the following fields:
+- __output:__ path to write to. Writes to `process.stdout` by default
+
 ## Installation
 ```sh
 $ git clone https://github.com/TabDigital/org-checks

--- a/output/csv.js
+++ b/output/csv.js
@@ -1,0 +1,41 @@
+const stdout = require('stdout-stream')
+const csv = require('csv-write-stream')
+const pump = require('pump')
+const fs = require('fs')
+
+module.exports = toCsv
+
+// print to a csv stream
+// obj -> null
+function toCsv (opts) {
+  opts = opts || {}
+  opts.fail = opts.fail === undefined ? true : opts.fail
+
+  return function (data, cb) {
+    const rs = createCsvStream(data)
+    const ws = opts.output
+      ? fs.createWriteStream(opts.output)
+      : stdout
+
+    pump(rs, ws, cb)
+  }
+}
+
+// create a csv stream from data
+// [obj] -> rstream
+function createCsvStream (data) {
+  const rs = csv({ headers: [ 'name', 'type', 'data' ] })
+  data.forEach(function (chunk) {
+    if (chunk.type === 'summary') {
+      rs.write({
+        name: chunk.name,
+        type: chunk.type,
+        data: 'failures: ' + data.fail + 'total: ' + data.total
+      })
+    } else {
+      rs.write(chunk)
+    }
+  })
+  rs.end()
+  return rs
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "csv-write-stream": "^1.0.0",
     "from2-string": "^1.1.0",
     "ghutils": "^3.2.0",
     "hipchat-client": "^1.0.4",


### PR DESCRIPTION
Adds a `csv` output. Useful to dump logs that can be parsed using `grep` or in gists or smth. Cheers!