### PR TITLE
input/credentials: add whitelist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ every aspect of an organization.
 ```
 
 ## Input
-### credentials(organization, opts)
-Check existance of `AWS_KEY`, `.pem`, `id_rsa` and `.key` files. Opts has the
+### credentials(organization, auth, opts)
+Check existance of `AWS_KEY`, `.pem`, `id_rsa` and `.key` files. Auth has the
 following fields:
 - __user:__ GitHub user (required)
 - __token:__ GitHub OpenAuth token (required)
+- __whitelist:__ (optional) Object of arrays of which paths are whitelisted.
+  Entries should have a signature of `{ repo, file }` pointing to the
+  repository and file to be ignored.
 
 ### stale(organization, auth, opts?)
 Check for stale repositories. By default projects are considered stale after 6

--- a/input/credentials.js
+++ b/input/credentials.js
@@ -13,6 +13,7 @@ function awsCredentialScraper (org, auth, opts) {
   assert.equal(typeof auth.token, 'string', 'auth.token must be a string')
 
   opts = opts || {}
+  if (!opts.whitelist) opts.whitelist = []
 
   const ghOpts = ghutils.makeOptions(auth)
   const uris = [
@@ -69,7 +70,13 @@ function awsCredentialScraper (org, auth, opts) {
         if (res.total_count === 0) return cb(null, [])
 
         const errs = res.items.reduce(function (arr, item) {
-          arr.push({ name: name, type: 'fail', data: item.html_url })
+          // only push if not whitelisted
+          const matches = opts.whitelist.some(function (el) {
+            return el.file === item.path && el.repo === item.repository.name
+          })
+          if (!matches) {
+            arr.push({ name: name, type: 'fail', data: item.html_url })
+          }
           return arr
         }, [])
 


### PR DESCRIPTION
Related to https://github.com/TabDigital/backlog-platform-team/issues/29, https://github.com/TabDigital/backlog-platform-team/issues/9

Implements a whitelist option for `input/credentials`. 

cc/ @rprieto @TabDigital/public-api 
